### PR TITLE
Remove http:BearerAuthHandler definition from user config

### DIFF
--- a/src/gsheets4/gsheets_endpoint.bal
+++ b/src/gsheets4/gsheets_endpoint.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerina/io;
+import ballerina/oauth2;
 
 # Google Spreadsheet Client object.
 #
@@ -25,7 +26,16 @@ public type Client client object {
     public http:Client spreadsheetClient;
 
     public function __init(SpreadsheetConfiguration spreadsheetConfig) {
-        self.spreadsheetClient = new(BASE_URL, spreadsheetConfig.clientConfig);
+        // Create OAuth2 provider.
+        oauth2:OutboundOAuth2Provider oauth2Provider = new(spreadsheetConfig.clientConfig);
+        // Create bearer auth handler using created provider.
+        http:BearerAuthHandler bearerHandler = new(oauth2Provider);
+        // Create salesforce http client.
+        self.spreadsheetClient = new(BASE_URL, {
+            auth: {
+                authHandler: bearerHandler
+            }
+        });
     }
 
     # Create a new spreadsheet.
@@ -403,5 +413,5 @@ public type Client client object {
 #
 # + clientConfig - The http client endpoint
 public type SpreadsheetConfiguration record {
-    http:ClientEndpointConfig clientConfig;
+    oauth2:DirectTokenConfig clientConfig;
 };

--- a/src/gsheets4/gsheets_utils.bal
+++ b/src/gsheets4/gsheets_utils.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 
 function setResponseError(json jsonResponse) returns error {
-    error err = error(SPREADSHEET_ERROR_CODE, message = jsonResponse.message.toString());
+    error err = error(SPREADSHEET_ERROR_CODE, message = jsonResponse.toString());
     return err;
 }
 

--- a/src/gsheets4/tests/test.bal
+++ b/src/gsheets4/tests/test.bal
@@ -21,23 +21,18 @@ import ballerina/log;
 import ballerina/http;
 import ballerina/oauth2;
 
-oauth2:OutboundOAuth2Provider oauth2Provider = new({
-    accessToken: "ya29.xxxxxxx",
-    refreshConfig: {
-        clientId: "xxxxxxx",
-        clientSecret: "xxxxxxx",
-        refreshUrl: REFRESH_URL,
-        refreshToken: "1/Rxxxxxxx"
-    }
-});
-http:BearerAuthHandler oauth2Handler = new(oauth2Provider);
 SpreadsheetConfiguration spreadsheetConfig = {
     clientConfig: {
-        auth: {
-            authHandler: oauth2Handler
+        accessToken: "<accessToken>",
+        refreshConfig: {
+            clientId: "<clientId>",
+            clientSecret: "<clientSecret>",
+            refreshUrl: REFRESH_URL,
+            refreshToken: "<refreshToken>"
         }
     }
 };
+
 Client spreadsheetClient = new(spreadsheetConfig);
 
 Spreadsheet testSpreadsheet = new;


### PR DESCRIPTION
## Purpose
Removed http:BearerAuthHandler definition from user config and added it to the client init function.

Previous config
```ballerina
import wso2/gsheets4;

oauth2:OutboundOAuth2Provider oauth2Provider = new({
    accessToken: "<accessToken>",
    refreshConfig: {
        clientId: "<clientId>",
        clientSecret: "<clientSecret>",
        refreshUrl: REFRESH_URL,
        refreshToken: "<refreshToken>"
    }
});
http:BearerAuthHandler oauth2Handler = new(oauth2Provider);
SpreadsheetConfiguration spreadsheetConfig = {
    clientConfig: {
        auth: {
            authHandler: oauth2Handler
        }
    }
};

Client spreadsheetClient = new(spreadsheetConfig);
```
Config after the change
```ballerina
SpreadsheetConfiguration spreadsheetConfig = {
    clientConfig: {
        accessToken: "<accessToken>",
        refreshConfig: {
            clientId: "<clientId>",
            clientSecret: "<clientSecret>",
            refreshUrl: REFRESH_URL,
            refreshToken: "<refreshToken>"
        }
    }
};

Client spreadsheetClient = new(spreadsheetConfig);
```