### PR TITLE
Migrate the Ballerina version to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget https://product-dist.ballerina.io/downloads/1.0.1/ballerina-linux-installer-x64-1.0.1.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-1.0.1.deb
+  - wget https://product-dist.ballerina.io/downloads/1.1.0/ballerina-linux-installer-x64-1.1.0.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-1.1.0.deb
   - sudo apt-get install -f
   - ballerina --version
   - ballerina build -c --skip-tests gsheets4

--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,4 +1,4 @@
 org_name = "wso2"
-version = "0.9.1"
+version = "0.10.0"
 lockfile_version = "1.0.0"
-ballerina_version = "1.0.1"
+ballerina_version = "1.1.0"

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name = "wso2"
-version = "0.9.1"
+version = "0.10.0"
 license= ["Apache-2.0"]
 authors = ["WSO2"]
 keywords = ["gsheets", "google", "spreadsheet"]

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The following sections provide you with information on how to use the Ballerina 
 
 ### Compatibility
 
-| Ballerina Language Version  | Google Spreadsheet API Version |
+| Ballerina Language Versions  | Google Spreadsheet API Version |
 |:---------------------------:|:------------------------------:|
-|  1.0.1                     |   V4                           |
+|  1.0.x, 1.1.x                     |   V4                           |
 
 ##### Prerequisites
 Download the ballerina [distribution](https://ballerinalang.org/downloads/).

--- a/src/gsheets4/Module.md
+++ b/src/gsheets4/Module.md
@@ -21,9 +21,9 @@ The `wso2/gsheets4` module allows you to perform following operations.
 
 ## Compatibility
 
-|                             |       Version               |
+|                             |       Versions               |
 |:---------------------------:|:---------------------------:|
-| Ballerina Language          | 1.0.1                     |
+| Ballerina Language          | 1.0.x, 1.1.x                     |
 | Google Spreadsheet API      | V4                          |
 
 ## Sample


### PR DESCRIPTION
## Purpose
> Migrate the Google Spreadsheet Connector from Ballerina version 1.0.1 to 1.1.0.